### PR TITLE
Add {min,max}_value assoc funcs to FXP

### DIFF
--- a/ni-fpga-macros/Cargo.toml
+++ b/ni-fpga-macros/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "ni-fpga-macros"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
-license = "MIT"
 license-file = "LICENSE.md"
 description = "Macros to be used with the ni-fpga crate."
 repository = "https://github.com/first-rust-competition/ni-fpga-rs"

--- a/ni-fpga-sys/Cargo.toml
+++ b/ni-fpga-sys/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "ni-fpga-sys"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
-license = "MIT"
 license-file = "LICENSE.md"
 description = "Rust bindings to the NI FPGA C API."
 repository = "https://github.com/first-rust-competition/ni-fpga-rs"

--- a/ni-fpga/Cargo.toml
+++ b/ni-fpga/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "ni-fpga"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Connor Worley <connorbworley@gmail.com>"]
 edition = "2018"
-license = "MIT"
 license-file = "LICENSE.md"
 description = "Safe Rust interface to NI FPGAs."
 readme = "README.md"
@@ -11,5 +10,5 @@ repository = "https://github.com/first-rust-competition/ni-fpga-rs"
 
 [dependencies]
 bitvec = "0.17.4"
-ni-fpga-sys = { version = "1.0.0", path = "../ni-fpga-sys" }
+ni-fpga-sys = { version = "1.0.1", path = "../ni-fpga-sys" }
 thiserror = "1.0.19"

--- a/ni-fpga/src/fxp.rs
+++ b/ni-fpga/src/fxp.rs
@@ -115,11 +115,27 @@ impl<const WORD_LENGTH: u8, const INTEGER_LENGTH: u8, const SIGNED: bool>
         }
     }
 
-    fn abs(self) -> Self {
+    pub fn abs(self) -> Self {
         if !SIGNED || self.0 & Self::SIGN_MASK == 0 {
             self
         } else {
             Self((self.0 ^ Self::WORD_MASK) + 1)
+        }
+    }
+
+    pub fn max_value() -> Self {
+        if !SIGNED {
+            Self(Self::WORD_MASK)
+        } else {
+            Self(Self::WORD_MASK ^ Self::SIGN_MASK)
+        }
+    }
+
+    pub fn min_value() -> Self {
+        if !SIGNED {
+            Self(0)
+        } else {
+            Self(Self::SIGN_MASK)
         }
     }
 }


### PR DESCRIPTION
also remove extra license key from Cargo.toml tiles.